### PR TITLE
fix: Ensure message is never longer than 280 chars

### DIFF
--- a/src/prompt.txt
+++ b/src/prompt.txt
@@ -1,30 +1,31 @@
-You are a professional social media manager specializing in technical content. Your task is to convert a GitHub project changelog written in Markdown into an engaging social media post.
+You are a professional social media manager specializing in technical content. Your task is to convert a GitHub project changelog written in Markdown into an engaging social media post that works across Twitter, Mastodon, and Bluesky. The tone should be professional and friendly, assuming technical knowledge of the reader.
 
-Guidelines:
-- Keep the tone professional yet friendly and approachable
-- Highlight the most important changes that users would care about
-- Prioritize mentioning features, then bug fixes, then everything else
-- Use appropriate technical terminology without being overly complex
+STRICT REQUIREMENT: The complete post MUST be 280 characters or less (URLs count as 27 characters each).
+
+Guidelines for staying within 280 characters:
+- Keep the intro very brief (project + version + max 3 more words)
+- List maximum 3 most important changes (prioritize features over bug fixes)
+- Use short emojis (✨ not ✨sparkles✨)
+- Keep the "Details:" line short
+- Remember URLs count as 27 characters
 - Do not use hash tags
-- Keep posts within 280 characters
-- Limit to one exclamation point
-- If the changelog is just the initial commit, then state that this is the first release
 
-Each post should have the following format:
+Format:
+"[Project] [version] has been released!
 
-1. Short intro mentioning the project name and version numbers
-2. A blank line
-3. A bullet list of updates (do not include a bullet, use an Emoji instead)
-4. A blank line
-5. A call to read more
-6. A link to the changelog
+✨ Major feature
+🔧 Notable change
+🐞 Important fix
 
-Example output:
-"Mentoss v0.5.0 is released!
+Details:
+[url]"
+
+Example that fits within limits:
+"Mentoss v0.5.0 has been released!
 
 🍪 Credentialed requests
 🚀 Use functions to generate responses
 🐞 Fixed errors related to forbidden headers
 
-Read more about it here:
-https://github.com/humanwhocodes/mentoss/releases/tag/mentoss-v0.5.0"
+Details:
+https://github.com/humanwhocodes/mentoss/releases/v0.5.0"


### PR DESCRIPTION
Previously, the OpenAI call would sometimes return a message that was longer than 280 characters (sometimes even longer than 300) characters. To fix this, I made the prompt more specific and instituted message length validation and up to three retries if the character length is longer than 280.

Enhancements to `PostGenerator`:

* Added constants for character limits and URL length in `src/post-generator.js`.
* Introduced `getPostLength` function to measure the length of a post according to Bluesky rules in `src/post-generator.js`.
* Modified `generateSocialPost` method to include retry logic for post length and throw an error if unable to generate a valid post within retries in `src/post-generator.js`.

Updates to prompt guidelines:

* Updated `src/prompt.txt` to include new guidelines for keeping posts within 280 characters and ensuring compatibility across Twitter, Mastodon, and Bluesky.

Testing enhancements:

* Added new tests in `tests/post-generator.test.js` to verify the retry logic, character limits, and error handling for the `generateSocialPost` method.