### PR TITLE
fix: Ensure post is surrounded by quotes

### DIFF
--- a/src/post-generator.js
+++ b/src/post-generator.js
@@ -72,6 +72,15 @@ function getPostLength(text) {
 	return text.replace(urlRegex, "x".repeat(URL_LENGTH)).length;
 }
 
+/**
+ * Removes leading and trailing quotation marks from a string.
+ * @param {string} text The text to clean.
+ * @returns {string} The text without leading/trailing quotes.
+ */
+function removeQuotes(text) {
+	return text.replace(/^["']|["']$/g, "").trim();
+}
+
 //-----------------------------------------------------------------------------
 // Exports
 //-----------------------------------------------------------------------------
@@ -186,8 +195,9 @@ export class PostGenerator {
 				throw new Error("No content received from OpenAI");
 			}
 
-			if (getPostLength(post) <= MAX_CHARACTERS) {
-				return post;
+			const cleanPost = removeQuotes(post);
+			if (getPostLength(cleanPost) <= MAX_CHARACTERS) {
+				return cleanPost;
 			}
 
 			attempts++;

--- a/src/prompt.txt
+++ b/src/prompt.txt
@@ -4,13 +4,13 @@ STRICT REQUIREMENT: The complete post MUST be 280 characters or less (URLs count
 
 Guidelines for staying within 280 characters:
 - Keep the intro very brief (project + version + max 3 more words)
-- List maximum 3 most important changes (prioritize features over bug fixes)
+- List 1-3 most important changes (prioritize features over bug fixes)
 - Use short emojis (✨ not ✨sparkles✨)
 - Keep the "Details:" line short
 - Remember URLs count as 27 characters
 - Do not use hash tags
 
-Format:
+Format (do not include the starting and ending quotation marks in the actual post):
 "[Project] [version] has been released!
 
 ✨ Major feature

--- a/tests/post-generator.test.js
+++ b/tests/post-generator.test.js
@@ -174,6 +174,37 @@ describe("PostGenerator", () => {
 				},
 			);
 		});
+
+		it("should remove leading and trailing quotation marks from the response", async () => {
+			const responseWithQuotes = {
+				choices: [
+					{
+						message: {
+							content: '"Test message with quotes"',
+						},
+					},
+				],
+			};
+
+			server.post("/v1/chat/completions", {
+				status: 200,
+				body: responseWithQuotes,
+				headers: {
+					"content-type": "application/json",
+					authorization: `Bearer ${OPENAI_TOKEN}`,
+				},
+			});
+
+			const generator = new PostGenerator(OPENAI_TOKEN, {
+				prompt: MOCK_PROMPT,
+			});
+
+			const post = await generator.generateSocialPost(
+				"testproject",
+				MOCK_RELEASE,
+			);
+			assert.strictEqual(post, "Test message with quotes");
+		});
 	});
 
 	describe("generateSocialPost() character limits", () => {


### PR DESCRIPTION
In some cases, gpt-4o-mini is returning a post with quotes around it due to the prompt.  This PR updates the prompt to specify not to include quotes and also checks the returned value to strip any quotes it might have.

Improvements to post content handling:

* [`src/post-generator.js`](diffhunk://#diff-93c82f1ef4bf24f8172a2c5049ffa80f8a9f5308c389a9434398e4f0645e437fR75-R83): Added a `removeQuotes` function to remove leading and trailing quotation marks from a string.
* [`src/post-generator.js`](diffhunk://#diff-93c82f1ef4bf24f8172a2c5049ffa80f8a9f5308c389a9434398e4f0645e437fL189-R200): Updated the `PostGenerator` class to use the `removeQuotes` function before checking the post length.

Guideline updates:

* [`src/prompt.txt`](diffhunk://#diff-661d53c077d774c1d318d5e1bd91ed05de7bf521f49724d6b30235e51023a7a9L7-R13): Modified guidelines to specify listing 1-3 most important changes and clarified the format for posts.

Testing enhancements:

* [`tests/post-generator.test.js`](diffhunk://#diff-869682b3fe1eb608376bf881c899b3d01127c7e63b095a0df65ab018e26c25f0R177-R207): Added a test case to ensure the `removeQuotes` function correctly removes leading and trailing quotation marks from the response.