### PR TITLE
feat: Switch to OpenAI Responses API

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -4,111 +4,146 @@
  */
 
 export interface GitHubRelease {
-    url: string;
-    assets_url: string;
-    upload_url: string;
-    html_url: string;
-    id: number;
-    author: {
-        login: string;
-        id: number;
-        node_id: string;
-        avatar_url: string;
-        gravatar_id: string;
-        url: string;
-        html_url: string;
-        followers_url: string;
-        following_url: string;
-        gists_url: string;
-        starred_url: string;
-        subscriptions_url: string;
-        organizations_url: string;
-        repos_url: string;
-        events_url: string;
-        received_events_url: string;
-        type: string;
-        site_admin: boolean;
-    };
-    node_id: string;
-    tag_name: string;
-    target_commitish: string;
-    name: string;
-    draft: boolean;
-    prerelease: boolean;
-    created_at: string;
-    published_at: string;
-    assets: Array<{
-        url: string;
-        id: number;
-        node_id: string;
-        name: string;
-        label: string;
-        uploader: {
-            login: string;
-            id: number;
-            node_id: string;
-            avatar_url: string;
-            gravatar_id: string;
-            url: string;
-            html_url: string;
-            followers_url: string;
-            following_url: string;
-            gists_url: string;
-            starred_url: string;
-            subscriptions_url: string;
-            organizations_url: string;
-            repos_url: string;
-            events_url: string;
-            received_events_url: string;
-            type: string;
-            site_admin: boolean;
-        };
-        content_type: string;
-        state: string;
-        size: number;
-        download_count: number;
-        created_at: string;
-        updated_at: string;
-        browser_download_url: string;
-    }>;
-    tarball_url: string;
-    zipball_url: string;
-    body: string;
+	url: string;
+	assets_url: string;
+	upload_url: string;
+	html_url: string;
+	id: number;
+	author: {
+		login: string;
+		id: number;
+		node_id: string;
+		avatar_url: string;
+		gravatar_id: string;
+		url: string;
+		html_url: string;
+		followers_url: string;
+		following_url: string;
+		gists_url: string;
+		starred_url: string;
+		subscriptions_url: string;
+		organizations_url: string;
+		repos_url: string;
+		events_url: string;
+		received_events_url: string;
+		type: string;
+		site_admin: boolean;
+	};
+	node_id: string;
+	tag_name: string;
+	target_commitish: string;
+	name: string;
+	draft: boolean;
+	prerelease: boolean;
+	created_at: string;
+	published_at: string;
+	assets: Array<{
+		url: string;
+		id: number;
+		node_id: string;
+		name: string;
+		label: string;
+		uploader: {
+			login: string;
+			id: number;
+			node_id: string;
+			avatar_url: string;
+			gravatar_id: string;
+			url: string;
+			html_url: string;
+			followers_url: string;
+			following_url: string;
+			gists_url: string;
+			starred_url: string;
+			subscriptions_url: string;
+			organizations_url: string;
+			repos_url: string;
+			events_url: string;
+			received_events_url: string;
+			type: string;
+			site_admin: boolean;
+		};
+		content_type: string;
+		state: string;
+		size: number;
+		download_count: number;
+		created_at: string;
+		updated_at: string;
+		browser_download_url: string;
+	}>;
+	tarball_url: string;
+	zipball_url: string;
+	body: string;
 }
 
 export interface ReleaseInfo {
-    tagName: string;
-    version: string;
-    url: string;
-    details: string;
+	tagName: string;
+	version: string;
+	url: string;
+	details: string;
 }
 
-export interface GptMessage {
-    role: string;
-    content: string;
+export interface OpenAIResponseContent {
+	type: "output_text";
+	text: string;
+	annotations: Array<unknown>;
 }
 
-export interface GptChatCompletionResponse {
-    id: string;
-    object: string;
-    created: number;
-    model: string;
-    choices: Array<{
-        index: number;
-        message: GptMessage;
-        finish_reason: string;
-    }>;
-    usage: {
-        prompt_tokens: number;
-        completion_tokens: number;
-        total_tokens: number;
-    };
+export interface OpenAIResponseMessage {
+	type: "message";
+	id: string;
+	status: string;
+	role: string;
+	content: Array<OpenAIResponseContent>;
+}
+
+export interface OpenAIResponse {
+	id: string;
+	object: "response";
+	created_at: number;
+	status: string;
+	error: null | object;
+	incomplete_details: null | object;
+	instructions: null | string;
+	max_output_tokens: null | number;
+	model: string;
+	output: Array<OpenAIResponseMessage>;
+	parallel_tool_calls: boolean;
+	previous_response_id: null | string;
+	reasoning: {
+		effort: null | string;
+		summary: null | string;
+	};
+	store: boolean;
+	temperature: number;
+	text: {
+		format: {
+			type: string;
+		};
+	};
+	tool_choice: string;
+	tools: Array<unknown>;
+	top_p: number;
+	truncation: string;
+	usage: {
+		input_tokens: number;
+		input_tokens_details: {
+			cached_tokens: number;
+		};
+		output_tokens: number;
+		output_tokens_details: {
+			reasoning_tokens: number;
+		};
+		total_tokens: number;
+	};
+	user: null | string;
+	metadata: object;
 }
 
 export interface CLIArgs {
-    org: string | undefined;
-    repo: string | undefined;
-    name: string | undefined;
-    tag: string | undefined;
-    help: boolean | undefined;
+	org: string | undefined;
+	repo: string | undefined;
+	name: string | undefined;
+	tag: string | undefined;
+	help: boolean | undefined;
 }

--- a/tests/cli.test.js
+++ b/tests/cli.test.js
@@ -44,12 +44,16 @@ const MOCK_RELEASE = {
 	body: "Test release notes",
 };
 
-const MOCK_COMPLETION = {
-	choices: [
+const MOCK_RESPONSE = {
+	id: "resp_123",
+	output: [
 		{
-			message: {
-				content: "Generated post",
-			},
+			content: [
+				{
+					type: "output_text",
+					text: "Generated post",
+				},
+			],
 		},
 	],
 };
@@ -155,9 +159,9 @@ describe("CLI", () => {
 				body: MOCK_RELEASE,
 			});
 
-			openAIServer.post("/v1/chat/completions", {
+			openAIServer.post("/v1/responses", {
 				status: 200,
-				body: MOCK_COMPLETION,
+				body: MOCK_RESPONSE,
 				headers: {
 					"content-type": "application/json",
 					authorization: "Bearer test-token",
@@ -182,9 +186,9 @@ describe("CLI", () => {
 				body: MOCK_RELEASE,
 			});
 
-			openAIServer.post("/v1/chat/completions", {
+			openAIServer.post("/v1/responses", {
 				status: 200,
-				body: MOCK_COMPLETION,
+				body: MOCK_RESPONSE,
 				headers: {
 					"content-type": "application/json",
 					authorization: "Bearer test-token",
@@ -229,7 +233,7 @@ describe("CLI", () => {
 				body: MOCK_RELEASE,
 			});
 
-			openAIServer.post("/v1/chat/completions", {
+			openAIServer.post("/v1/responses", {
 				status: 500,
 				body: { error: "Internal Server Error" },
 			});
@@ -244,7 +248,9 @@ describe("CLI", () => {
 			]);
 
 			assert.equal(exitCode, 1);
-			assert.ok(testConsole.errors[0].includes("Chat completion failed"));
+			assert.ok(
+				testConsole.errors[0].includes("Response generation failed"),
+			);
 		});
 	});
 


### PR DESCRIPTION
This pull request includes significant changes to the `PostGenerator` class and its related files to update the API response handling and improve the retry logic. The main changes involve updating the API endpoint, modifying the response structure, and enhancing the test cases to reflect these updates.

### API and Response Handling Updates:

* [`src/post-generator.js`](diffhunk://#diff-93c82f1ef4bf24f8172a2c5049ffa80f8a9f5308c389a9434398e4f0645e437fL21-R21): Updated the API endpoint from `/v1/chat/completions` to `/v1/responses`, changed the response structure to use `OpenAIResponse`, and added a new method `#extractGeneratedText` to handle the response extraction. [[1]](diffhunk://#diff-93c82f1ef4bf24f8172a2c5049ffa80f8a9f5308c389a9434398e4f0645e437fL21-R21) [[2]](diffhunk://#diff-93c82f1ef4bf24f8172a2c5049ffa80f8a9f5308c389a9434398e4f0645e437fL46-L63) [[3]](diffhunk://#diff-93c82f1ef4bf24f8172a2c5049ffa80f8a9f5308c389a9434398e4f0645e437fL128-R158) [[4]](diffhunk://#diff-93c82f1ef4bf24f8172a2c5049ffa80f8a9f5308c389a9434398e4f0645e437fR169-R192)

### Type Definitions:

* [`src/types.ts`](diffhunk://#diff-c54113cf61ec99691748a3890bfbeb00e10efb3f0a76f03a0fd9ec49072e410aL86-R140): Replaced `GptMessage` and `GptChatCompletionResponse` with `OpenAIResponseMessage` and `OpenAIResponse` to match the new response structure.

### Test Case Updates:

* [`tests/post-generator.test.js`](diffhunk://#diff-869682b3fe1eb608376bf881c899b3d01127c7e63b095a0df65ab018e26c25f0L28-R37): Updated test cases to reflect the new API endpoint and response structure. Added a new test case to verify the correct handling of `previous_response_id` during retries. [[1]](diffhunk://#diff-869682b3fe1eb608376bf881c899b3d01127c7e63b095a0df65ab018e26c25f0L28-R37) [[2]](diffhunk://#diff-869682b3fe1eb608376bf881c899b3d01127c7e63b095a0df65ab018e26c25f0L83-R88) [[3]](diffhunk://#diff-869682b3fe1eb608376bf881c899b3d01127c7e63b095a0df65ab018e26c25f0L100-R167) [[4]](diffhunk://#diff-869682b3fe1eb608376bf881c899b3d01127c7e63b095a0df65ab018e26c25f0L121-R183) [[5]](diffhunk://#diff-869682b3fe1eb608376bf881c899b3d01127c7e63b095a0df65ab018e26c25f0L144-R201) [[6]](diffhunk://#diff-869682b3fe1eb608376bf881c899b3d01127c7e63b095a0df65ab018e26c25f0L159-R229) [[7]](diffhunk://#diff-869682b3fe1eb608376bf881c899b3d01127c7e63b095a0df65ab018e26c25f0L213-R285) [[8]](diffhunk://#diff-869682b3fe1eb608376bf881c899b3d01127c7e63b095a0df65ab018e26c25f0L255-R316) [[9]](diffhunk://#diff-869682b3fe1eb608376bf881c899b3d01127c7e63b095a0df65ab018e26c25f0L278-R365)