### PR TITLE
feat: Add --prompt-file CLI option

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -36,13 +36,41 @@ x => x + x
 
 ```javascript
 for (let i = 0, n = str.length; i < 10; i++) {
-    if (x < 10) {
-        foo();
-    }
+	if (x < 10) {
+		foo();
+	}
 }
 
 function f(x: number, y: string): void { }
 ```
+
+## Project Structure
+
+- Use `src` for source code
+    - TypeScript types are found in `src/types.ts`
+- Use `tests` for test code
+    - Test files have the same name as the source file they are testing, but with a `.test.js` suffix
+    - Use a `fixtures` subfolder in `tests` for test data files (e.g., prompt files)
+
+## Coding Approach
+
+- Tests should always be updated to reflect the latest changes, especially for new CLI flags or options (e.g., `--prompt-file`)
+- The README file should always be updated to document new CLI options and usage examples
+- Use `async/await` for asynchronous code
+- Use `Promise.all` for parallel asynchronous code
+- When adding CLI flags, ensure argument parsing uses camelCase in code and kebab-case for CLI, and map as needed
+- Always handle file paths robustly in tests (prefer `path.resolve` for test fixture files)
+- `console` can only be used in `cli.js`.
+    - Use `console.log` for logging messages to the user
+    - Use `console.error` for errors
+    - Do not use `console` for debugging (except for temporary debug output during test troubleshooting)
+
+## Commands
+
+- Use `npm test` to run all tests
+    - To test an individual file use `npx mocha tests/<test-file>.test.js`
+- Use `npm run lint` to run the linter
+- Use `npm run fmt` to format the code
 
 ## OpenAI API
 

--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ npx social-changelog --org <org> --repo <repo> --name <project-name>
 - `--repo, -r` - The repository name
 - `--name, -n` - (Optional) The display name of the project (defaults to org/repo)
 - `--tag, -t` - (Optional) Specific release tag to use (defaults to latest)
+- `--prompt-file` - (Optional) Path to a file containing a custom prompt to use instead of the default
 - `--help, -h` - Show help information
 
 ### CLI Examples
@@ -50,6 +51,12 @@ Generate post for latest release:
 
 ```bash
 npx social-changelog --org humanwhocodes --repo social-changelog
+```
+
+Use a custom prompt file:
+
+```bash
+npx social-changelog --org humanwhocodes --repo social-changelog --prompt-file ./my-prompt.txt
 ```
 
 By default, the `org/repo` will be used as the project name. You can override this by providing the `--name` option:

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "fmt": "prettier --write .",
     "prepublishOnly": "npm run build",
     "pretest": "npm run build",
-    "test:unit": "mocha --exit tests/**/*.*",
+    "test:unit": "mocha --exit tests/**/*.js",
     "test:jsr": "npx jsr@latest publish --dry-run",
     "test": "npm run test:unit"
   },

--- a/src/types.ts
+++ b/src/types.ts
@@ -146,6 +146,7 @@ export interface CLIArgs {
 	name: string | undefined;
 	tag: string | undefined;
 	help: boolean | undefined;
+	promptFile?: string;
 }
 
 export interface GptMessage {

--- a/tests/fixtures/prompt-custom.txt
+++ b/tests/fixtures/prompt-custom.txt
@@ -1,0 +1,1 @@
+You are a test prompt for the CLI --prompt-file option. Only output the word: CUSTOMPROMPT

--- a/tests/prompt-custom.txt
+++ b/tests/prompt-custom.txt
@@ -1,0 +1,1 @@
+You are a test prompt for the CLI --prompt-file option. Only output the word: CUSTOMPROMPT


### PR DESCRIPTION
This pull request introduces a new `--prompt-file` CLI option to allow users to specify a custom prompt file for generating social posts. It also includes updates to the project structure, coding guidelines, and tests to support this feature. The most important changes are grouped below:

### New Feature: `--prompt-file` CLI Option
* Added support for a `--prompt-file` option in the CLI, allowing users to specify a custom prompt file. The file's contents are read and passed to the post generator. (`src/cli.js`: [[1]](diffhunk://#diff-a3751a8ca1ab5bdf5d4bb6b4c3861d9a81205bc01b080e57301090b6e8b34165R83-R104) [[2]](diffhunk://#diff-a3751a8ca1ab5bdf5d4bb6b4c3861d9a81205bc01b080e57301090b6e8b34165R131-R142) [[3]](diffhunk://#diff-a3751a8ca1ab5bdf5d4bb6b4c3861d9a81205bc01b080e57301090b6e8b34165R159)
* Updated the `CLIArgs` interface in `src/types.ts` to include an optional `promptFile` property. (`src/types.ts`: [src/types.tsR149](diffhunk://#diff-c54113cf61ec99691748a3890bfbeb00e10efb3f0a76f03a0fd9ec49072e410aR149))
* Enhanced error handling for reading the custom prompt file, logging errors to the console if the file cannot be read. (`src/cli.js`: [src/cli.jsR83-R104](diffhunk://#diff-a3751a8ca1ab5bdf5d4bb6b4c3861d9a81205bc01b080e57301090b6e8b34165R83-R104))

### Documentation Updates
* Updated the `README.md` to document the new `--prompt-file` option and provide usage examples. (`README.md`: [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R45) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R56-R61)
* Added a new "Project Structure" and "Coding Approach" section to `.github/copilot-instructions.md` to clarify coding and testing practices. (`.github/copilot-instructions.md`: [.github/copilot-instructions.mdR47-R74](diffhunk://#diff-227c2c26cb2ee0ce0f46a320fc48fbcbdf21801a57f59161b1d0861e8aad55f5R47-R74))

### Testing Enhancements
* Added a test case to verify the functionality of the `--prompt-file` option, including reading a custom prompt file and using it in the CLI. (`tests/cli.test.js`: [tests/cli.test.jsR314-R364](diffhunk://#diff-a10d59e19abc9e0640788b7741c09da6ed522076ca44d34b952486a4fa12242dR314-R364))
* Introduced a new test fixture file, `prompt-custom.txt`, to support the `--prompt-file` test case. (`tests/fixtures/prompt-custom.txt`: [[1]](diffhunk://#diff-cbc500cdfef306ab2be2a1238eba1cfeffe074c8006fefa9582ea6ad0db0b37eR1) `tests/prompt-custom.txt`: [[2]](diffhunk://#diff-cbc500cdfef306ab2be2a1238eba1cfeffe074c8006fefa9582ea6ad0db0b37eR1)